### PR TITLE
feat: more backend rules

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -63,7 +63,22 @@ module.exports = {
     'no-param-reassign': 0,
     'no-underscore-dangle': 0,
     'no-use-before-define': 0,
-    'no-console': 0,
+    'no-console': ['error', { allow: ['error'] }],
+    'padding-line-between-statements': 'off',
+    '@typescript-eslint/padding-line-between-statements': [
+      'error',
+      // blank line before return
+      { blankLine: 'always', prev: '*', next: 'return' },
+      // blank line before and after block like statements
+      { blankLine: 'always', prev: '*', next: 'block-like' },
+      { blankLine: 'always', prev: 'block-like', next: '*' },
+      // blank line before and after function declarations
+      { blankLine: 'always', prev: '*', next: 'function' },
+      { blankLine: 'always', prev: 'function', next: '*' }
+    ],
+    'spaced-comment': 'error',
+    // default case in a switch needs to be last
+    'default-case-last': 'error',
 
     'import/order': [
       'error',


### PR DESCRIPTION
Added some rules which I was either using myself locally already and/or fit our current coding style:
- `console.*` calls aren't allowed except for `console.error` which imo is useful because you can utilize it before e.g. a logger is available because Nest hasn't started yet
- space when starting comments `//lorem` -> `// lorem`
- the default case in a switch needs to be the last
- empty line before returning
- empty line before & after block-like statements and function declarations

Closes #44 