### PR TITLE
fix(prettier): useTabs: true 🍿

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -1,125 +1,125 @@
 module.exports = {
-  parser: '@typescript-eslint/parser',
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-    'plugin:import/errors',
-    'plugin:import/warnings',
-    'plugin:import/typescript',
-  ],
-  plugins: ['prettier'],
-  parserOptions: {
-    ecmaVersion: 2017,
-    sourceType: 'module',
-    project: './tsconfig.json',
-  },
-  env: {
-    node: true,
-    es6: true,
-    jest: true,
-  },
-  settings: {
-    'import/resolver': {
-      alias: {
-        map: [
-          ['@module', './src/modules'],
-          ['@common', './src/common'],
-          ['@util', './src/util'],
-        ],
-        extensions: ['.js', '.ts'],
-      },
-      node: {
-        extensions: ['.js', '.ts'],
-      },
-    },
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts'],
-    },
-  },
-  rules: {
-    '@typescript-eslint/explicit-function-return-type': ['off'],
-    '@typescript-eslint/explicit-member-accessibility': [1],
-    '@typescript-eslint/interface-name-prefix': [0, 'never'],
-    '@typescript-eslint/no-explicit-any': 0,
-    '@typescript-eslint/no-namespace': 0,
-    '@typescript-eslint/no-inferrable-types': 0,
-    'import/extensions': [
-      1,
-      'never',
-      {
-        svg: 'always',
-      },
-    ],
-    'import/no-extraneous-dependencies': [
-      'error',
-      {
-        devDependencies: true,
-        optionalDependencies: false,
-        peerDependencies: false,
-      },
-    ],
-    'no-param-reassign': 0,
-    'no-underscore-dangle': 0,
-    'no-use-before-define': 0,
-    'no-console': ['error', { allow: ['error'] }],
-    'padding-line-between-statements': 'off',
-    '@typescript-eslint/padding-line-between-statements': [
-      'error',
-      // blank line before return
-      { blankLine: 'always', prev: '*', next: 'return' },
-      // blank line before and after block like statements
-      { blankLine: 'always', prev: '*', next: 'block-like' },
-      { blankLine: 'always', prev: 'block-like', next: '*' },
-      // blank line before and after function declarations
-      { blankLine: 'always', prev: '*', next: 'function' },
-      { blankLine: 'always', prev: 'function', next: '*' }
-    ],
-    'spaced-comment': 'error',
-    // default case in a switch needs to be last
-    'default-case-last': 'error',
+	parser: '@typescript-eslint/parser',
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/eslint-recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:prettier/recommended',
+		'plugin:import/errors',
+		'plugin:import/warnings',
+		'plugin:import/typescript',
+	],
+	plugins: ['prettier'],
+	parserOptions: {
+		ecmaVersion: 2017,
+		sourceType: 'module',
+		project: './tsconfig.json',
+	},
+	env: {
+		node: true,
+		es6: true,
+		jest: true,
+	},
+	settings: {
+		'import/resolver': {
+			alias: {
+				map: [
+					['@module', './src/modules'],
+					['@common', './src/common'],
+					['@util', './src/util'],
+				],
+				extensions: ['.js', '.ts'],
+			},
+			node: {
+				extensions: ['.js', '.ts'],
+			},
+		},
+		'import/parsers': {
+			'@typescript-eslint/parser': ['.ts'],
+		},
+	},
+	rules: {
+		'@typescript-eslint/explicit-function-return-type': ['off'],
+		'@typescript-eslint/explicit-member-accessibility': [1],
+		'@typescript-eslint/interface-name-prefix': [0, 'never'],
+		'@typescript-eslint/no-explicit-any': 0,
+		'@typescript-eslint/no-namespace': 0,
+		'@typescript-eslint/no-inferrable-types': 0,
+		'import/extensions': [
+			1,
+			'never',
+			{
+				svg: 'always',
+			},
+		],
+		'import/no-extraneous-dependencies': [
+			'error',
+			{
+				devDependencies: true,
+				optionalDependencies: false,
+				peerDependencies: false,
+			},
+		],
+		'no-param-reassign': 0,
+		'no-underscore-dangle': 0,
+		'no-use-before-define': 0,
+		'no-console': ['error', { allow: ['error'] }],
+		'padding-line-between-statements': 'off',
+		'@typescript-eslint/padding-line-between-statements': [
+			'error',
+			// blank line before return
+			{ blankLine: 'always', prev: '*', next: 'return' },
+			// blank line before and after block like statements
+			{ blankLine: 'always', prev: '*', next: 'block-like' },
+			{ blankLine: 'always', prev: 'block-like', next: '*' },
+			// blank line before and after function declarations
+			{ blankLine: 'always', prev: '*', next: 'function' },
+			{ blankLine: 'always', prev: 'function', next: '*' },
+		],
+		'spaced-comment': 'error',
+		// default case in a switch needs to be last
+		'default-case-last': 'error',
 
-    'import/order': [
-      'error',
-      {
-        alphabetize: {
-          order: 'asc',
-          caseInsensitive: true,
-        },
-        groups: ['builtin', 'external', ['internal', 'parent'], ['sibling', 'index']],
-        pathGroups: [
-          {
-            pattern: 'react',
-            group: 'external',
-            position: 'before',
-          },
-          {
-            pattern: '@**',
-            group: 'internal',
-            position: 'before',
-          },
-          {
-            pattern: '@**/**',
-            group: 'internal',
-            position: 'before',
-          },
-        ],
-        pathGroupsExcludedImportTypes: [],
-      },
-    ],
+		'import/order': [
+			'error',
+			{
+				alphabetize: {
+					order: 'asc',
+					caseInsensitive: true,
+				},
+				groups: ['builtin', 'external', ['internal', 'parent'], ['sibling', 'index']],
+				pathGroups: [
+					{
+						pattern: 'react',
+						group: 'external',
+						position: 'before',
+					},
+					{
+						pattern: '@**',
+						group: 'internal',
+						position: 'before',
+					},
+					{
+						pattern: '@**/**',
+						group: 'internal',
+						position: 'before',
+					},
+				],
+				pathGroupsExcludedImportTypes: [],
+			},
+		],
 
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 120,
-        semi: true,
-        singleQuote: true,
-        tabWidth: 2,
-        trailingComma: 'none',
-        useTabs: false,
-        arrowParens: 'avoid',
-      },
-    ],
-  },
+		'prettier/prettier': [
+			'error',
+			{
+				printWidth: 120,
+				semi: true,
+				singleQuote: true,
+				tabWidth: 2,
+				trailingComma: 'none',
+				useTabs: true,
+				arrowParens: 'avoid',
+			},
+		],
+	},
 };

--- a/index.js
+++ b/index.js
@@ -1,57 +1,57 @@
 module.exports = {
-  extends: ['prettier'],
-  plugins: ['@typescript-eslint', 'import', 'prettier'],
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.ts'],
-      },
-    },
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts'],
-    },
-  },
-  rules: {
-    // come up with some nice rules here
+	extends: ['prettier'],
+	plugins: ['@typescript-eslint', 'import', 'prettier'],
+	settings: {
+		'import/resolver': {
+			node: {
+				extensions: ['.js', '.ts'],
+			},
+		},
+		'import/parsers': {
+			'@typescript-eslint/parser': ['.ts'],
+		},
+	},
+	rules: {
+		// come up with some nice rules here
 
-    'import/order': [
-      'error',
-      {
-        alphabetize: {
-          order: 'asc',
-          caseInsensitive: true,
-        },
-        groups: ['builtin', 'external', ['internal', 'parent'], ['sibling', 'index']],
-        pathGroups: [
-          {
-            pattern: 'react',
-            group: 'external',
-            position: 'before',
-          },
-          {
-            pattern: '~**',
-            group: 'internal',
-            position: 'before',
-          },
-          {
-            pattern: '~**/**',
-            group: 'internal',
-            position: 'before',
-          },
-        ],
-        pathGroupsExcludedImportTypes: [],
-      },
-    ],
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 100,
-        semi: true,
-        singleQuote: true,
-        tabWidth: 2,
-        trailingComma: 'all',
-        useTabs: false,
-      },
-    ],
-  },
+		'import/order': [
+			'error',
+			{
+				alphabetize: {
+					order: 'asc',
+					caseInsensitive: true,
+				},
+				groups: ['builtin', 'external', ['internal', 'parent'], ['sibling', 'index']],
+				pathGroups: [
+					{
+						pattern: 'react',
+						group: 'external',
+						position: 'before',
+					},
+					{
+						pattern: '~**',
+						group: 'internal',
+						position: 'before',
+					},
+					{
+						pattern: '~**/**',
+						group: 'internal',
+						position: 'before',
+					},
+				],
+				pathGroupsExcludedImportTypes: [],
+			},
+		],
+		'prettier/prettier': [
+			'error',
+			{
+				printWidth: 100,
+				semi: true,
+				singleQuote: true,
+				tabWidth: 2,
+				trailingComma: 'all',
+				useTabs: true,
+			},
+		],
+	},
 };

--- a/react.js
+++ b/react.js
@@ -1,331 +1,331 @@
 module.exports = {
-  root: true,
-  extends: ['prettier', 'plugin:mdx/recommended'],
-  plugins: ['import', 'jsx-a11y', 'react', 'react-hooks', 'prettier'],
-  env: {
-    browser: true,
-    commonjs: true,
-    es6: true,
-    jest: true,
-    node: true,
-  },
-  parserOptions: {
-    ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-  settings: {
-    react: {
-      version: 'detect',
-    },
-    'import/resolver': {
-      alias: [
-        ['~components', './src/components'],
-        ['~styles', './src/styles'],
-        ['~hooks', './src/hooks'],
-        ['~config', './src/config'],
-        ['~lib', './src/lib'],
-      ],
-    },
-  },
-  overrides: [
-    {
-      files: [
-        '*.stories.js',
-        '*.stories.tsx',
-        '*.stories.ts',
-        '*.test.tsx',
-        '*.test.ts',
-        'test-utils.tsx',
-      ],
-      rules: {
-        'import/no-extraneous-dependencies': 'off',
-        'import/named': 'off', //@todo fix fireEvent not found in test-utils
-      },
-    },
-    {
-      files: ['**/*.ts?(x)'],
-      parser: '@typescript-eslint/parser',
-      parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: 'module',
-        ecmaFeatures: {
-          jsx: true,
-        },
-        // typescript-eslint specific options
-        warnOnUnsupportedTypeScriptVersion: true,
-      },
-      plugins: ['@typescript-eslint'],
-      // If adding a typescript-eslint version of an existing ESLint rule,
-      // make sure to disable the ESLint rule here.
-      rules: {
-        // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
-        'default-case': 'off',
-        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
-        'no-dupe-class-members': 'off',
-        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
-        'no-undef': 'off',
+	root: true,
+	extends: ['prettier', 'plugin:mdx/recommended'],
+	plugins: ['import', 'jsx-a11y', 'react', 'react-hooks', 'prettier'],
+	env: {
+		browser: true,
+		commonjs: true,
+		es6: true,
+		jest: true,
+		node: true,
+	},
+	parserOptions: {
+		ecmaVersion: 2018,
+		sourceType: 'module',
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+	settings: {
+		react: {
+			version: 'detect',
+		},
+		'import/resolver': {
+			alias: [
+				['~components', './src/components'],
+				['~styles', './src/styles'],
+				['~hooks', './src/hooks'],
+				['~config', './src/config'],
+				['~lib', './src/lib'],
+			],
+		},
+	},
+	overrides: [
+		{
+			files: [
+				'*.stories.js',
+				'*.stories.tsx',
+				'*.stories.ts',
+				'*.test.tsx',
+				'*.test.ts',
+				'test-utils.tsx',
+			],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+				'import/named': 'off', //@todo fix fireEvent not found in test-utils
+			},
+		},
+		{
+			files: ['**/*.ts?(x)'],
+			parser: '@typescript-eslint/parser',
+			parserOptions: {
+				ecmaVersion: 2018,
+				sourceType: 'module',
+				ecmaFeatures: {
+					jsx: true,
+				},
+				// typescript-eslint specific options
+				warnOnUnsupportedTypeScriptVersion: true,
+			},
+			plugins: ['@typescript-eslint'],
+			// If adding a typescript-eslint version of an existing ESLint rule,
+			// make sure to disable the ESLint rule here.
+			rules: {
+				// TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
+				'default-case': 'off',
+				// 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+				'no-dupe-class-members': 'off',
+				// 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+				'no-undef': 'off',
 
-        // Add TypeScript specific rules (and turn off ESLint equivalents)
-        '@typescript-eslint/consistent-type-assertions': 'warn',
-        'no-array-constructor': 'off',
-        '@typescript-eslint/no-array-constructor': 'warn',
-        'no-use-before-define': 'off',
-        '@typescript-eslint/no-use-before-define': [
-          'warn',
-          {
-            functions: false,
-            classes: false,
-            variables: false,
-            typedefs: false,
-          },
-        ],
-        'no-unused-expressions': 'off',
-        '@typescript-eslint/no-unused-expressions': [
-          'error',
-          {
-            allowShortCircuit: true,
-            allowTernary: true,
-            allowTaggedTemplates: true,
-          },
-        ],
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': [
-          'warn',
-          {
-            args: 'none',
-            ignoreRestSiblings: true,
-          },
-        ],
-        'no-useless-constructor': 'off',
-        '@typescript-eslint/no-useless-constructor': 'warn',
-      },
-    },
-  ],
-  // NOTE: When adding rules here, you need to make sure they are compatible with
-  // `typescript-eslint`, as some rules such as `no-array-constructor` aren't compatible.
-  rules: {
-    // http://eslint.org/docs/rules/
-    'array-callback-return': 'error',
-    'default-case': ['error', { commentPattern: '^no default$' }],
-    'dot-location': ['error', 'property'],
-    eqeqeq: ['error', 'smart'],
-    'new-parens': 'error',
-    'no-array-constructor': 'error',
-    'no-caller': 'error',
-    'no-cond-assign': ['error', 'except-parens'],
-    'no-const-assign': 'error',
-    'no-control-regex': 'error',
-    'no-delete-var': 'error',
-    'no-dupe-args': 'error',
-    'no-dupe-class-members': 'error',
-    'no-dupe-keys': 'error',
-    'no-duplicate-case': 'error',
-    'no-empty-character-class': 'error',
-    'no-empty-pattern': 'error',
-    'no-eval': 'error',
-    'no-ex-assign': 'error',
-    'no-extend-native': 'error',
-    'no-extra-bind': 'error',
-    'no-extra-label': 'error',
-    'no-fallthrough': 'error',
-    'no-func-assign': 'error',
-    'no-implied-eval': 'error',
-    'no-invalid-regexp': 'error',
-    'no-iterator': 'error',
-    'no-label-var': 'error',
-    'no-labels': ['error', { allowLoop: true, allowSwitch: false }],
-    'no-lone-blocks': 'error',
-    'no-loop-func': 'error',
-    'no-mixed-operators': [
-      'error',
-      {
-        groups: [
-          ['&', '|', '^', '~', '<<', '>>', '>>>'],
-          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-          ['&&', '||'],
-          ['in', 'instanceof'],
-        ],
-        allowSamePrecedence: false,
-      },
-    ],
-    'no-multi-str': 'error',
-    'no-native-reassign': 'error',
-    'no-negated-in-lhs': 'error',
-    'no-new-func': 'error',
-    'no-new-object': 'error',
-    'no-new-symbol': 'error',
-    'no-new-wrappers': 'error',
-    'no-obj-calls': 'error',
-    'no-octal': 'error',
-    'no-octal-escape': 'error',
-    // TODO: Remove this option in the next major release of CRA.
-    // https://eslint.org/docs/user-guide/migrating-to-6.0.0#-the-no-redeclare-rule-is-now-more-strict-by-default
-    'no-redeclare': ['error', { builtinGlobals: false }],
-    'no-regex-spaces': 'error',
-    'no-restricted-syntax': ['error', 'WithStatement'],
-    'no-script-url': 'error',
-    'no-self-assign': 'error',
-    'no-self-compare': 'error',
-    'no-sequences': 'error',
-    'no-shadow-restricted-names': 'error',
-    'no-sparse-arrays': 'error',
-    'no-template-curly-in-string': 'error',
-    'no-this-before-super': 'error',
-    'no-throw-literal': 'error',
-    'no-undef': 'error',
-    'no-unreachable': 'error',
-    'no-unused-expressions': [
-      'error',
-      {
-        allowShortCircuit: true,
-        allowTernary: true,
-        allowTaggedTemplates: true,
-      },
-    ],
-    'no-unused-labels': 'error',
-    'no-unused-vars': [
-      'error',
-      {
-        args: 'none',
-        ignoreRestSiblings: true,
-      },
-    ],
-    'no-use-before-define': [
-      'error',
-      {
-        functions: false,
-        classes: false,
-        variables: false,
-      },
-    ],
-    'no-useless-computed-key': 'error',
-    'no-useless-concat': 'error',
-    'no-useless-constructor': 'error',
-    'no-useless-escape': 'error',
-    'no-useless-rename': [
-      'error',
-      {
-        ignoreDestructuring: false,
-        ignoreImport: false,
-        ignoreExport: false,
-      },
-    ],
-    'no-with': 'error',
-    'no-whitespace-before-property': 'error',
-    'react-hooks/exhaustive-deps': 'off',
-    'require-yield': 'error',
-    'rest-spread-spacing': ['error', 'never'],
-    strict: ['error', 'never'],
-    'unicode-bom': ['error', 'never'],
-    'use-isnan': 'error',
-    'valid-typeof': 'error',
-    'no-restricted-properties': [
-      'error',
-      {
-        object: 'require',
-        property: 'ensure',
-        message:
-          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
-      },
-      {
-        object: 'System',
-        property: 'import',
-        message:
-          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
-      },
-    ],
-    'getter-return': 'error',
-    // https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules
-    'import/first': 'error',
-    'import/no-amd': 'error',
-    'import/no-webpack-loader-syntax': 'error',
-    // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
-    'react/forbid-foreign-prop-types': ['error', { allowInPropTypes: true }],
-    'react/jsx-no-comment-textnodes': 'error',
-    'react/jsx-no-duplicate-props': 'error',
-    'react/jsx-no-target-blank': 'error',
-    'react/jsx-no-undef': 'error',
-    'react/jsx-pascal-case': [
-      'error',
-      {
-        allowAllCaps: true,
-        ignore: [],
-      },
-    ],
-    'react/jsx-uses-react': 'error',
-    'react/jsx-uses-vars': 'error',
-    'react/no-danger-with-children': 'error',
-    // Disabled because of undesirable warnings
-    // See https://github.com/facebook/create-react-app/issues/5204 for
-    // blockers until its re-enabled
-    // 'react/no-deprecated': 'warn',
-    'react/no-direct-mutation-state': 'error',
-    'react/no-is-mounted': 'error',
-    'react/no-typos': 'error',
-    // 'react/react-in-jsx-scope': 'error',
-    'react/require-render-return': 'error',
-    'react/style-prop-object': 'error',
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
-    'jsx-a11y/accessible-emoji': 'error',
-    'jsx-a11y/alt-text': 'error',
-    'jsx-a11y/anchor-has-content': 'error',
-    'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
-    'jsx-a11y/aria-props': 'error',
-    'jsx-a11y/aria-proptypes': 'error',
-    'jsx-a11y/aria-role': ['error', { ignoreNonDOM: true }],
-    'jsx-a11y/aria-unsupported-elements': 'error',
-    'jsx-a11y/heading-has-content': 'error',
-    'jsx-a11y/iframe-has-title': 'error',
-    'jsx-a11y/img-redundant-alt': 'error',
-    'jsx-a11y/no-access-key': 'error',
-    'jsx-a11y/no-distracting-elements': 'error',
-    'jsx-a11y/no-redundant-roles': 'error',
-    'jsx-a11y/role-has-required-aria-props': 'error',
-    'jsx-a11y/role-supports-aria-props': 'error',
-    'jsx-a11y/scope': 'error',
-    // https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks
-    'react-hooks/rules-of-hooks': 'error',
-    'import/order': [
-      'error',
-      {
-        alphabetize: {
-          order: 'asc',
-          caseInsensitive: true,
-        },
-        groups: ['builtin', 'external', ['internal', 'parent'], ['sibling', 'index']],
-        pathGroups: [
-          {
-            pattern: 'react',
-            group: 'external',
-            position: 'before',
-          },
-          {
-            pattern: '~**',
-            group: 'internal',
-            position: 'before',
-          },
-          {
-            pattern: '~**/**',
-            group: 'internal',
-            position: 'before',
-          },
-        ],
-        pathGroupsExcludedImportTypes: [],
-      },
-    ],
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 80,
-        semi: true,
-        singleQuote: true,
-        tabWidth: 2,
-        trailingComma: 'all',
-        useTabs: false,
-      },
-    ],
-  },
+				// Add TypeScript specific rules (and turn off ESLint equivalents)
+				'@typescript-eslint/consistent-type-assertions': 'warn',
+				'no-array-constructor': 'off',
+				'@typescript-eslint/no-array-constructor': 'warn',
+				'no-use-before-define': 'off',
+				'@typescript-eslint/no-use-before-define': [
+					'warn',
+					{
+						functions: false,
+						classes: false,
+						variables: false,
+						typedefs: false,
+					},
+				],
+				'no-unused-expressions': 'off',
+				'@typescript-eslint/no-unused-expressions': [
+					'error',
+					{
+						allowShortCircuit: true,
+						allowTernary: true,
+						allowTaggedTemplates: true,
+					},
+				],
+				'no-unused-vars': 'off',
+				'@typescript-eslint/no-unused-vars': [
+					'warn',
+					{
+						args: 'none',
+						ignoreRestSiblings: true,
+					},
+				],
+				'no-useless-constructor': 'off',
+				'@typescript-eslint/no-useless-constructor': 'warn',
+			},
+		},
+	],
+	// NOTE: When adding rules here, you need to make sure they are compatible with
+	// `typescript-eslint`, as some rules such as `no-array-constructor` aren't compatible.
+	rules: {
+		// http://eslint.org/docs/rules/
+		'array-callback-return': 'error',
+		'default-case': ['error', { commentPattern: '^no default$' }],
+		'dot-location': ['error', 'property'],
+		eqeqeq: ['error', 'smart'],
+		'new-parens': 'error',
+		'no-array-constructor': 'error',
+		'no-caller': 'error',
+		'no-cond-assign': ['error', 'except-parens'],
+		'no-const-assign': 'error',
+		'no-control-regex': 'error',
+		'no-delete-var': 'error',
+		'no-dupe-args': 'error',
+		'no-dupe-class-members': 'error',
+		'no-dupe-keys': 'error',
+		'no-duplicate-case': 'error',
+		'no-empty-character-class': 'error',
+		'no-empty-pattern': 'error',
+		'no-eval': 'error',
+		'no-ex-assign': 'error',
+		'no-extend-native': 'error',
+		'no-extra-bind': 'error',
+		'no-extra-label': 'error',
+		'no-fallthrough': 'error',
+		'no-func-assign': 'error',
+		'no-implied-eval': 'error',
+		'no-invalid-regexp': 'error',
+		'no-iterator': 'error',
+		'no-label-var': 'error',
+		'no-labels': ['error', { allowLoop: true, allowSwitch: false }],
+		'no-lone-blocks': 'error',
+		'no-loop-func': 'error',
+		'no-mixed-operators': [
+			'error',
+			{
+				groups: [
+					['&', '|', '^', '~', '<<', '>>', '>>>'],
+					['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+					['&&', '||'],
+					['in', 'instanceof'],
+				],
+				allowSamePrecedence: false,
+			},
+		],
+		'no-multi-str': 'error',
+		'no-native-reassign': 'error',
+		'no-negated-in-lhs': 'error',
+		'no-new-func': 'error',
+		'no-new-object': 'error',
+		'no-new-symbol': 'error',
+		'no-new-wrappers': 'error',
+		'no-obj-calls': 'error',
+		'no-octal': 'error',
+		'no-octal-escape': 'error',
+		// TODO: Remove this option in the next major release of CRA.
+		// https://eslint.org/docs/user-guide/migrating-to-6.0.0#-the-no-redeclare-rule-is-now-more-strict-by-default
+		'no-redeclare': ['error', { builtinGlobals: false }],
+		'no-regex-spaces': 'error',
+		'no-restricted-syntax': ['error', 'WithStatement'],
+		'no-script-url': 'error',
+		'no-self-assign': 'error',
+		'no-self-compare': 'error',
+		'no-sequences': 'error',
+		'no-shadow-restricted-names': 'error',
+		'no-sparse-arrays': 'error',
+		'no-template-curly-in-string': 'error',
+		'no-this-before-super': 'error',
+		'no-throw-literal': 'error',
+		'no-undef': 'error',
+		'no-unreachable': 'error',
+		'no-unused-expressions': [
+			'error',
+			{
+				allowShortCircuit: true,
+				allowTernary: true,
+				allowTaggedTemplates: true,
+			},
+		],
+		'no-unused-labels': 'error',
+		'no-unused-vars': [
+			'error',
+			{
+				args: 'none',
+				ignoreRestSiblings: true,
+			},
+		],
+		'no-use-before-define': [
+			'error',
+			{
+				functions: false,
+				classes: false,
+				variables: false,
+			},
+		],
+		'no-useless-computed-key': 'error',
+		'no-useless-concat': 'error',
+		'no-useless-constructor': 'error',
+		'no-useless-escape': 'error',
+		'no-useless-rename': [
+			'error',
+			{
+				ignoreDestructuring: false,
+				ignoreImport: false,
+				ignoreExport: false,
+			},
+		],
+		'no-with': 'error',
+		'no-whitespace-before-property': 'error',
+		'react-hooks/exhaustive-deps': 'off',
+		'require-yield': 'error',
+		'rest-spread-spacing': ['error', 'never'],
+		strict: ['error', 'never'],
+		'unicode-bom': ['error', 'never'],
+		'use-isnan': 'error',
+		'valid-typeof': 'error',
+		'no-restricted-properties': [
+			'error',
+			{
+				object: 'require',
+				property: 'ensure',
+				message:
+					'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+			},
+			{
+				object: 'System',
+				property: 'import',
+				message:
+					'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+			},
+		],
+		'getter-return': 'error',
+		// https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules
+		'import/first': 'error',
+		'import/no-amd': 'error',
+		'import/no-webpack-loader-syntax': 'error',
+		// https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
+		'react/forbid-foreign-prop-types': ['error', { allowInPropTypes: true }],
+		'react/jsx-no-comment-textnodes': 'error',
+		'react/jsx-no-duplicate-props': 'error',
+		'react/jsx-no-target-blank': 'error',
+		'react/jsx-no-undef': 'error',
+		'react/jsx-pascal-case': [
+			'error',
+			{
+				allowAllCaps: true,
+				ignore: [],
+			},
+		],
+		'react/jsx-uses-react': 'error',
+		'react/jsx-uses-vars': 'error',
+		'react/no-danger-with-children': 'error',
+		// Disabled because of undesirable warnings
+		// See https://github.com/facebook/create-react-app/issues/5204 for
+		// blockers until its re-enabled
+		// 'react/no-deprecated': 'warn',
+		'react/no-direct-mutation-state': 'error',
+		'react/no-is-mounted': 'error',
+		'react/no-typos': 'error',
+		// 'react/react-in-jsx-scope': 'error',
+		'react/require-render-return': 'error',
+		'react/style-prop-object': 'error',
+		// https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
+		'jsx-a11y/accessible-emoji': 'error',
+		'jsx-a11y/alt-text': 'error',
+		'jsx-a11y/anchor-has-content': 'error',
+		'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
+		'jsx-a11y/aria-props': 'error',
+		'jsx-a11y/aria-proptypes': 'error',
+		'jsx-a11y/aria-role': ['error', { ignoreNonDOM: true }],
+		'jsx-a11y/aria-unsupported-elements': 'error',
+		'jsx-a11y/heading-has-content': 'error',
+		'jsx-a11y/iframe-has-title': 'error',
+		'jsx-a11y/img-redundant-alt': 'error',
+		'jsx-a11y/no-access-key': 'error',
+		'jsx-a11y/no-distracting-elements': 'error',
+		'jsx-a11y/no-redundant-roles': 'error',
+		'jsx-a11y/role-has-required-aria-props': 'error',
+		'jsx-a11y/role-supports-aria-props': 'error',
+		'jsx-a11y/scope': 'error',
+		// https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks
+		'react-hooks/rules-of-hooks': 'error',
+		'import/order': [
+			'error',
+			{
+				alphabetize: {
+					order: 'asc',
+					caseInsensitive: true,
+				},
+				groups: ['builtin', 'external', ['internal', 'parent'], ['sibling', 'index']],
+				pathGroups: [
+					{
+						pattern: 'react',
+						group: 'external',
+						position: 'before',
+					},
+					{
+						pattern: '~**',
+						group: 'internal',
+						position: 'before',
+					},
+					{
+						pattern: '~**/**',
+						group: 'internal',
+						position: 'before',
+					},
+				],
+				pathGroupsExcludedImportTypes: [],
+			},
+		],
+		'prettier/prettier': [
+			'error',
+			{
+				printWidth: 80,
+				semi: true,
+				singleQuote: true,
+				tabWidth: 2,
+				trailingComma: 'all',
+				useTabs: true,
+			},
+		],
+	},
 };


### PR DESCRIPTION
We discuss this at least once a year but I don't think we've ever actually settled on anything and just keep using spaces. I'm hoping that opening this PR will spark another convo in which we can settle if we're either going for tabs or keep sticking with spaces.

For me personally I've always been on the spaces side until I learned about the accessibility concerns of not using tabs. I've since then converted to tabs completely (existing projects and when starting out new ones). And there are not really any downside (to me), only benefits of being more accessible and giving developers more control on their own dev experience. Having that said you do have to do some customisations yourself as some defaults shipped by companies are pretty out there (I'm looking at you Github with a default of `tabSize: 8`).

Let me know how what ya'll are thinking on the whole thing 👍 

For more context and insights on the matter: [Prettier issue to make it the default](https://github.com/prettier/prettier/issues/7475) (still open, but most are on the fence of not "forcing" this on developers) 