### PR TITLE
feat: enforce trailing comma in backend

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -52,6 +52,7 @@ module.exports = {
 				svg: 'always',
 			},
 		],
+		'import/newline-after-import': ['error'],
 		'import/no-extraneous-dependencies': [
 			'error',
 			{
@@ -79,7 +80,6 @@ module.exports = {
 		'spaced-comment': 'error',
 		// default case in a switch needs to be last
 		'default-case-last': 'error',
-
 		'import/order': [
 			'error',
 			{
@@ -108,7 +108,6 @@ module.exports = {
 				pathGroupsExcludedImportTypes: [],
 			},
 		],
-
 		'prettier/prettier': [
 			'error',
 			{
@@ -116,7 +115,7 @@ module.exports = {
 				semi: true,
 				singleQuote: true,
 				tabWidth: 2,
-				trailingComma: 'none',
+				trailingComma: 'all',
 				useTabs: true,
 				arrowParens: 'avoid',
 			},


### PR DESCRIPTION
Reasoning for enforcing trailing comma:

> Trailing commas (sometimes called "final commas") can be useful when adding new elements, parameters, or properties to JavaScript code. If you want to add a new property, you can add a new line without modifying the previously last line if that line already uses a trailing comma. This makes version-control diffs cleaner and editing code might be less troublesome. - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas

_Note: This PR also adds one other rule with lower impact to enforce a newline after the import statements._