### PR TITLE
feat: remove alias mapping from backend config

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -22,14 +22,6 @@ module.exports = {
 	},
 	settings: {
 		'import/resolver': {
-			alias: {
-				map: [
-					['@module', './src/modules'],
-					['@common', './src/common'],
-					['@util', './src/util'],
-				],
-				extensions: ['.js', '.ts'],
-			},
 			node: {
 				extensions: ['.js', '.ts'],
 			},


### PR DESCRIPTION
The aliases are very repo specific and they need also need to be defined in the repo itself anyways, e.g. in the tsconfig, jest config and when using `addAliases` from `module-alias`. Currently when you add/change an alias, you will not be having a fun time, you will update all the aliases in all the different config files in the repo, but the eslint will keep complaining while you check a 100 times if you updated everything correctly (not me talking from experience 🥲).