### PR TITLE
feat: allow using underscores for unused arguments

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -37,6 +37,7 @@ module.exports = {
 		'@typescript-eslint/no-explicit-any': 0,
 		'@typescript-eslint/no-namespace': 0,
 		'@typescript-eslint/no-inferrable-types': 0,
+		'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '_' }],
 		'import/extensions': [
 			1,
 			'never',


### PR DESCRIPTION
Currently being imported via [`eslint/recommended`](https://github.com/typescript-eslint/typescript-eslint/blob/391a6702c0a9b5b3874a7a27047f2a721f090fb6/packages/eslint-plugin/src/configs/recommended.ts#L30) from [here](https://github.com/instantcommerce/eslint-config-instant/blob/master/backend.js#L4), sticking with `warn` and just adding the underscore as an ignore pattern