### PR TITLE
feat(backend): require usage of `await` when returning

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -38,6 +38,8 @@ module.exports = {
 		'@typescript-eslint/no-namespace': 0,
 		'@typescript-eslint/no-inferrable-types': 0,
 		'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '_' }],
+		'no-return-await': 'off',
+		'@typescript-eslint/return-await': ['error', 'always'],
 		'import/extensions': [
 			1,
 			'never',


### PR DESCRIPTION
Stealing the comment of @ggurkal on why using `return await ...` makes a difference and is a nice to have:

> technically it's not necessary but `await`ing will give the correct execution stack (journey of the code) when an error is encountered.
> 
> assuming the journey is like: resolver > service > event handler
> 
> without await, the stack trace will look like:
> 
> ```ts
> Error: the error message here
>   at Resolver.queryMethod (resolver.js:10:20)
>   at some node internals (blabla...)
> ```
> 
> with await:
> 
> ```ts
> Error: the error message here
>   at Resolver.queryMethod (resolver.js:10:20)
>   at Service.serviceMethod (service.js:10:20)
>   at Handler.handleMethod (handler.js:10:20)
>   at some node internals (blabla...)
> ```